### PR TITLE
use Twig_SimpleFilter method to define the twig-filter

### DIFF
--- a/Twig/Extension/Parsedown.php
+++ b/Twig/Extension/Parsedown.php
@@ -12,7 +12,7 @@ class Parsedown extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'markdown' => new \Twig_Filter_Method($this, 'parsedown', array('is_safe' => array('html'))),
+            'markdown' => new \Twig_SimpleFilter('markdown',array($this, 'parsedown'), array('is_safe' => array('html')))
         );
     }
 


### PR DESCRIPTION
The `Twig_Filter_Method` is deprecated - `Twig_SimpleFilter` should be used.

See deprecation-message:

> Using an instance of "Twig_Filter_Method" for filter "markdown" is deprecated since version 1.21. Use Twig_SimpleFilter instead.
